### PR TITLE
Use trust_env in requests by default

### DIFF
--- a/defrag/modules/helpers/requests.py
+++ b/defrag/modules/helpers/requests.py
@@ -14,7 +14,7 @@ class Req:
     @classmethod
     def get_session(cls) -> ClientSession:
         if not cls.session or cls.session.closed:
-            cls.session = ClientSession()
+            cls.session = ClientSession(trust_env=True)
         return cls.session
 
     @classmethod


### PR DESCRIPTION
This adds support for HTTP proxies in `Req`.