### PR TITLE
/help command

### DIFF
--- a/opengm/opengm.py
+++ b/opengm/opengm.py
@@ -1,7 +1,10 @@
 from typing import Any, List, Tuple
 
-from pyrogram import Client, __version__
+from pyrogram import Client, __version__, filters
 from pyrogram.types import Message
+from functools import partial
+
+command = partial(filters.command, prefixes="/")
 
 
 class Opengm(Client, Message):
@@ -37,3 +40,8 @@ class Opengm(Client, Message):
         user_id = message.from_user.id
         chat_id = message.chat.id
         return user_id in self.admins[chat_id]
+
+
+@Opengm.on_message(filters.command("test"))
+async def test(cl: Client, msg: Message):
+    await msg.reply("Test!")

--- a/opengm/opengm.py
+++ b/opengm/opengm.py
@@ -42,6 +42,3 @@ class Opengm(Client, Message):
         return user_id in self.admins[chat_id]
 
 
-@Opengm.on_message(filters.command("test"))
-async def test(cl: Client, msg: Message):
-    await msg.reply("Test!")

--- a/opengm/plugins/core.py
+++ b/opengm/plugins/core.py
@@ -9,7 +9,15 @@ from opengm.utils.commands import get_args
 # Do not register this plugin!
 
 LOGGER = logging.getLogger(__name__)
-HELPTEXT = "Hey there! My name is {}.\nI'm a modular group management bot with a few fun extras! Have a look at the following for an idea of some of the things I can help you with.\n\n**Main** commands avaliable:\n - /start: start the bot\n - /help: PM's this message.\n - /help <module name>: PM's you help for that module."
+HELPTEXT = """
+Hey there! My name is {}.
+I'm a modular group management bot with a few fun extras! Have a look at the following for an idea of some of the things I can help you with.
+
+**Main** commands avaliable:
+- /start: start the bot
+- /help: PM's this message.
+- /help <module name>: PM's you help for that module.
+"""
 
 
 @Opengm.on_message(filters.command("help"))

--- a/opengm/plugins/main.py
+++ b/opengm/plugins/main.py
@@ -1,0 +1,51 @@
+import re
+import logging
+from pyrogram import Client, filters
+from pyrogram.types import Message, InlineKeyboardMarkup, CallbackQuery, InlineKeyboardButton
+from opengm.opengm import Opengm, command
+from opengm.utils.chat_status import user_admin
+from opengm.utils.plugins import HELPABLE, HELPABLE_LOWER, paginate_plugins
+from opengm.utils.commands import get_args
+# Do not register this plugin!
+
+LOGGER = logging.getLogger(__name__)
+HELPTEXT = "Hey there! My name is {}.\nI'm a modular group management bot with a few fun extras! Have a look at the following for an idea of some of the things I can help you with.\n\n**Main** commands avaliable:\n - /start: start the bot\n - /help: PM's this message.\n - /help <module name>: PM's you help for that module."
+
+
+@Opengm.on_message(filters.command("help"))
+async def help(cl: Client, message: Message) -> None:
+    args = get_args(message)
+    chat = message.chat
+    if chat.type != "private":
+        await message.reply("Contact me in PM to get the list of possible commands.", reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton(text="Help", url="t.me/{}?start=help".format((await cl.get_me()).username))]]))
+    else:
+        if len(args) == 0:
+            keyboard = InlineKeyboardMarkup(inline_keyboard=await paginate_plugins(0, HELPABLE, "help"))
+            await message.reply(HELPTEXT.format("Test"), reply_markup=keyboard)
+        elif args[0] in HELPABLE_LOWER:
+            text = HELPTEXT + "\n\nAnd the following:\n" + \
+                HELPABLE[HELPABLE_LOWER[args[0]]]
+            await message.reply(text, reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton(text="All modules", callback_data="help_back")]]))
+        else:
+            await message.reply("There is no plugin with that name.")
+
+
+@Opengm.on_callback_query(filters.regex(r"help_*"))
+async def help_button_callback(cl: Client, query: CallbackQuery) -> None:
+    mod_match = re.match(r"help_module\((.+?)\)", query.data)
+    prev_match = re.match(r"help_prev\((.+?)\)", query.data)
+    next_match = re.match(r"help_next\((.+?)\)", query.data)
+    back_match = re.match(r"help_back", query.data)
+    if mod_match:
+        module = mod_match.group(1)
+        text = HELPTEXT + "\n\nAnd the following:\n" + HELPABLE[module]
+        await query.message.reply(text, reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton(text="Back", callback_data="help_back")]]))
+    elif back_match:
+        await query.message.reply(HELPTEXT.format("Test"), reply_markup=InlineKeyboardMarkup(inline_keyboard=await paginate_plugins(0, HELPABLE, "help")))
+    elif prev_match:
+        curr_page = int(prev_match.group(1))
+        await query.message.reply(HELPTEXT, reply_markup=InlineKeyboardMarkup(paginate_modules(curr_page - 1, HELPABLE, "help")))
+    elif next_match:
+        next_page = int(next_match.group(1))
+        await query.message.reply(HELPTEXT, reply_markup=InlineKeyboardMarkup(paginate_modules(next_page + 1, HELPABLE, "help")))
+    await query.answer()

--- a/opengm/plugins/template_plugin.py
+++ b/opengm/plugins/template_plugin.py
@@ -1,14 +1,17 @@
 import time
-from functools import partial
-from pyrogram import Client, filters
+from pyrogram import Client
 from pyrogram.types import Message
-from opengm.opengm import Opengm
+from opengm.opengm import Opengm, command
+from opengm.utils.chat_status import user_admin
+from opengm.utils.plugins import register_plugin
 
-command = partial(filters.command, prefixes="/")
+register_plugin("Template", "This is a help text.")
+
 
 @Opengm.on_message(command("ping"))
+@user_admin
 async def ping(cl: Client, message: Message) -> None:
     start = time.time()
     reply = await message.reply_text("...")
     delta_ping = time.time() - start
-    await reply.edit_text(f"**OpenSUSE Bot Test!** `{delta_ping * 1000:.3f} ms`")
+    await reply.edit_text(f"**openSUSE Bot Test!** `{delta_ping * 1000:.3f} ms`")

--- a/opengm/utils/chat_status.py
+++ b/opengm/utils/chat_status.py
@@ -1,0 +1,29 @@
+from typing import Optional
+from functools import wraps
+from pyrogram import Client
+from pyrogram.types import Chat, ChatMember, Message
+
+
+async def is_user_admin(cl: Client, chat: Chat, user_id: int, member: ChatMember = None) -> bool:
+    if chat.type == 'private':
+        return True
+
+    if not member:
+        member = await cl.get_chat_member(chat.id, user_id)
+    return member.status in ('administrator', 'creator')
+
+
+def user_admin(func):
+    @wraps(func)
+    async def is_admin(cl: Client, message: Message, *args, **kwargs):
+        if message.chat.type == 'channel':
+            return await func(cl, message, *args, **kwargs)
+        user = message.from_user
+        if not user:
+            pass
+        if await is_user_admin(cl, message.chat, user.id):
+            return await func(cl, message, *args, **kwargs)
+        else:
+            await message.reply("Who dis non-admin telling me what to do?")
+
+    return is_admin

--- a/opengm/utils/commands.py
+++ b/opengm/utils/commands.py
@@ -1,0 +1,12 @@
+from pyrogram.types import Message
+from pyrogram import filters
+
+username = ""
+
+
+def get_args(msg: Message):
+    return msg.text.split()[1:]
+
+
+def command(command: str):
+    return filters.regex("^(!|/)help(@fancyhammerbot)?")

--- a/opengm/utils/plugins.py
+++ b/opengm/utils/plugins.py
@@ -1,0 +1,52 @@
+import logging
+from typing import List, Dict
+from pyrogram import Client, filters
+from pyrogram.types import InlineKeyboardButton, Message
+from math import ceil
+from opengm.opengm import Opengm, command
+
+LOGGER = logging.getLogger(__name__)
+LOADED = []
+HELPABLE = {}
+HELPABLE_LOWER = {}
+
+
+def register_plugin(plugin_name: str, help_text: str = None):
+    if plugin_name not in LOADED:
+        LOADED.append(plugin_name)
+    if plugin_name not in HELPABLE and help_text:
+        HELPABLE[plugin_name] = help_text
+        HELPABLE_LOWER[plugin_name.lower()] = plugin_name
+    LOGGER.info(f"Plugin '{plugin_name}' has been registered.")
+
+
+async def paginate_plugins(page_n: int, module_dict: Dict, prefix, chat=None) -> List:
+    modules = []
+    module_dict = dict(sorted(zip(module_dict.keys(), module_dict.values())))
+    if not chat:
+        for x in module_dict:
+            LOGGER.debug(module_dict[x])
+            modules.append(
+                InlineKeyboardButton(
+                    x, callback_data="{}_module({})".format(
+                        prefix, x)))
+    else:
+        for x in module_dict:
+            modules.append(
+                InlineKeyboardButton(
+                    x, callback_data="{}_module({},{})".format(
+                        prefix, x)))
+
+    pairs = list(zip(modules[::2], modules[1::2]))
+    if len(modules) % 2 == 1:
+        pairs.append((modules[-1],))
+    max_num_pages = ceil(len(pairs) / 7)
+    modulo_page = page_n % max_num_pages
+
+    # can only have a certain amount of buttons side by side
+    if len(pairs) > 7:
+        pairs = pairs[modulo_page * 7:7 * (modulo_page + 1)] + [
+            (InlineKeyboardButton("<", callback_data="{}_prev({})".format(prefix, modulo_page)),
+             InlineKeyboardButton(">", callback_data="{}_next({})".format(prefix, modulo_page)))]
+
+    return pairs


### PR DESCRIPTION
This adds a /help command, similar to the one in Nemesis:
![grafik](https://user-images.githubusercontent.com/38097062/134947337-d89b357b-e073-4d63-896b-c392255f1155.png)
Every (registered) plugin gets a button in the InlineKeyboard, if enough plugins are registered there are gonna be two columns and buttons to switch between multiple pages.
`/help` can be called in multiple ways:
* `/help <plugin>` in PM: Get help for the plugin.
* ` /help` in PM: Get the InlineKeyboard with all the plugins.
* `/help` in Group: Get a message with a button that redirects to PM.
In order to register a plugin, import `opengm.utils.plugins` and call `register_plugin()`, which takes the plugin name and the help text as arguments:
```python
from opengm.utils.plugins import register_plugin
register_plugin("Template", "This is a help text.")
```

This also adds the `@user_admin` decorator, allowing for commands only to be executed by group admins.