### PR TITLE
- profiling deps + instructions

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -34,6 +34,7 @@ aiohttp = "*"
 
 [dev-packages]
 autopep8 = "*"
+pytest-profiling = "*"
 
 [requires]
 python_version = "3.8"

--- a/profiling.md
+++ b/profiling.md
@@ -1,0 +1,10 @@
+## Profiling
+The application supports profiling-on-tests out of the box:
+
+1. Make sure you have `graphviz` installed. Reference: https://www.graphviz.org/.
+   - NB: No Python interface with this library is required. Not satisfying this dependency is likely to cause a "Broken pipe" error when running the command below.
+2. Run the tests with the appropriate flags, for example:
+    ```
+    pytest defrag/tests/unittests/test_suggestions.py --profile --profile-svg
+    ```
+    will write to disk profiling results, along with a nice SVG graph. (By default outputs can be found under `./prof`.)


### PR DESCRIPTION
This adds a pytest module for profiling. This should be helpful when running tests offline _and also_ when doing continuous testing in deployment, even though the latter will require one more system dependency (`graphviz`) that the production environment will need to satisfy.

Check `profiling.md` for the instructions.